### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -27,12 +27,3 @@ jobs:
         username: ${{ steps.ecr.outputs.username }}
         password: ${{ steps.ecr.outputs.password }}
         registry: ${{ steps.ecr.outputs.registry }}
-#     - name: Build the Docker image
-#       run: docker build . --file Dockerfile --tag gentle:$(date +%s)
-#     - name: Publish to Registry
-#       uses: elgohr/Publish-Docker-Github-Action@master
-#       with:
-#         name: hyperaudio/gentle
-#         username: ${{ secrets.DOCKER_USERNAME }}
-#         password: ${{ secrets.DOCKER_PASSWORD }}
-# #         registry: docker.pkg.github.com

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -21,7 +21,7 @@ jobs:
         secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         region: ${{ secrets.AWS_REGION }}
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: hyperaudio/gentle
         username: ${{ steps.ecr.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore